### PR TITLE
Remove body from redirect responses

### DIFF
--- a/src/ring/util/http_response.clj
+++ b/src/ring/util/http_response.clj
@@ -37,8 +37,7 @@
                 :body    ""}
                (cond
                  entity?   {:body 'body}
-                 location? {:headers {"Location" 'url}
-                            :body    `(str "<a href=\"" ~'url "\">" ~'url "</a>")}
+                 location? {:headers {"Location" 'url}}
                  :else     nil))]
     `(do
        (defn ~fn-name ~docstring ~parameters ~body)
@@ -133,4 +132,3 @@
    url-response
    resource-response
    get-header])
-

--- a/test/ring/util/http_response_test.clj
+++ b/test/ring/util/http_response_test.clj
@@ -23,14 +23,14 @@
     (im-used "body")                                => {:status 226 :headers {} :body "body"})
 
   (facts "Redirection"
-    (multiple-choices "/url")                       => {:status 300 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (moved-permanently "/url")                      => {:status 301 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (found "/url")                                  => {:status 302 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (see-other "/url")                              => {:status 303 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (not-modified "/url")                           => {:status 304 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (use-proxy "/url")                              => {:status 305 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (temporary-redirect "/url")                     => {:status 307 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"}
-    (permanent-redirect "/url")                     => {:status 308 :headers {"Location" "/url"} :body "<a href=\"/url\">/url</a>"})
+    (multiple-choices "/url")                       => {:status 300 :headers {"Location" "/url"} :body ""}
+    (moved-permanently "/url")                      => {:status 301 :headers {"Location" "/url"} :body ""}
+    (found "/url")                                  => {:status 302 :headers {"Location" "/url"} :body ""}
+    (see-other "/url")                              => {:status 303 :headers {"Location" "/url"} :body ""}
+    (not-modified "/url")                           => {:status 304 :headers {"Location" "/url"} :body ""}
+    (use-proxy "/url")                              => {:status 305 :headers {"Location" "/url"} :body ""}
+    (temporary-redirect "/url")                     => {:status 307 :headers {"Location" "/url"} :body ""}
+    (permanent-redirect "/url")                     => {:status 308 :headers {"Location" "/url"} :body ""})
 
   (facts "ClientError"
     (bad-request "body")                            => {:status 400 :headers {} :body "body"}


### PR DESCRIPTION
This change removes the anchor link from the body for redirect responses. There's no content-type set for these responses, and although this body is convenient it doesn't seem appropriate for a general purpose library. Our clients, for instance, don't expect to receive this kind of content from our API.

I've also changed the header key from `Location` to `location` as I think this is more appropriate for ring-compatible libraries.

Do these seem like reasonable changes?

I resisted doing this as part of this PR, but I also think that it would be good to remove the default `:headers {}` and `:body ""`. There's no reason to set these, and empty values don't fit very well with way Clojure writers typically check for existence using checks for truthiness (e.g. `(if (:body response) ...)`). What do you think?
