### PR TITLE
Fix 304

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .project
 .ccw*
 ccw*
+/.idea
+/*.iml

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -21,7 +21,7 @@
    [301 "Moved Permanently" "This and all future requests should be directed to the given URI."]
    [302 "Found" "The resource was found but at a different URI."]
    [303 "See Other" "The response to the request can be found under another URI using a GET method."]
-   [304 "Not Modified" "The resource has not been modified since last requested." {:entity? false}]
+   [304 "Not Modified" "The resource has not been modified since last requested." {:location? false}]
    [305 "Use Proxy" "This single request is to be repeated via the proxy given by the Location field."]
    [307 "Temporary Redirect" "The request should be repeated with another URI but future requests can still use the original URI."]
    [308 "Permanent Redirect" "The request and all future requests should be repeated using another URI."]

--- a/src/ring/util/http_response.clj
+++ b/src/ring/util/http_response.clj
@@ -156,9 +156,9 @@
 (defn not-modified
   "304 Not Modified (Redirection)
   The resource has not been modified since last requested."
-  ([url]
+  ([]
    {:status 304
-    :headers {"Location" url}
+    :headers {}
     :body ""}))
 
 (defn use-proxy

--- a/test/ring/util/http_response_test.clj
+++ b/test/ring/util/http_response_test.clj
@@ -27,7 +27,7 @@
     (moved-permanently "/url")                      => {:status 301 :headers {"Location" "/url"} :body ""}
     (found "/url")                                  => {:status 302 :headers {"Location" "/url"} :body ""}
     (see-other "/url")                              => {:status 303 :headers {"Location" "/url"} :body ""}
-    (not-modified "/url")                           => {:status 304 :headers {"Location" "/url"} :body ""}
+    (not-modified)                                  => {:status 304 :headers {} :body ""}
     (use-proxy "/url")                              => {:status 305 :headers {"Location" "/url"} :body ""}
     (temporary-redirect "/url")                     => {:status 307 :headers {"Location" "/url"} :body ""}
     (permanent-redirect "/url")                     => {:status 308 :headers {"Location" "/url"} :body ""})


### PR DESCRIPTION
According to http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5 the 304 Not Modified response should not have Location header.

This PR fixes that by changing 304 options to `{:location? false}`. The related test is changed too.