### PR TITLE
push (unsigned) releases to clojars via github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published # reacts to releases and prereleases, but not their drafts
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Setup Java 8"
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 8
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@master
+      with:
+        lein: latest
+    - name: Run tests
+      run: lein test
+    - name: Build uberjar
+      run: lein uberjar
+    - name: Deploy to Clojars
+      run: lein deploy
+      env:
+        CLOJARS_USER: metosinci
+        CLOJARS_DEPLOY_TOKEN: "${{ secrets.CLOJARS_DEPLOY_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ See the [facts](https://github.com/metosin/ring-http-response/blob/master/test/r
 These include: `status`, `header`, `file-response`, `content-type`, `find-header`, `get-header`, `update-header`, `charset`, `set-cookie`, `response?`
 `resource-data`, `url-response` and `resource-response`.
 
+## Making a release
+
+- Update `CHANGELOG.md` and increment the version number in `project.clj`
+- Commit
+- Tag with the release number
+- Push to Github
+- Create a Github release by editing the tag you just created on <https://github.com/metosin/ring-http-response/tags>
+- The [Github Actions release workflow](.github/workflows/release.yml) should fire and deploy a release to clojars
+
 ## License
 Original [code](https://github.com/spray/spray/blob/master/spray-http/src/main/scala/spray/http/StatusCode.scala): Copyright © 2011-2013 the spray project <http://spray.io>.
 

--- a/project.clj
+++ b/project.clj
@@ -17,5 +17,8 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}}
-  :deploy-repositories [["releases" :clojars]]
+  :deploy-repositories [["releases" {:url "https://repo.clojars.org/"
+                                     :sign-releases false
+                                     :username :env/CLOJARS_USER
+                                     :password :env/CLOJARS_DEPLOY_TOKEN}]]
   :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9:dev,1.10" "test"]})


### PR DESCRIPTION
based on https://github.com/opqdonut/clj-github-actions-example