### PR TITLE
Ignore common Clojure tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ ccw*
 /.idea
 /*.iml
 ;; Clojure tooling
-.clj-kondo
+.cache
 .lsp
 .calva

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ pom.xml.asc
 ccw*
 /.idea
 /*.iml
+;; Clojure tooling
+.clj-kondo
+.lsp
+.calva


### PR DESCRIPTION
Just a small change to ignore common tool directories.