### PR TITLE
Fix pre-expr syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please file bug reports and feature requests to https://github.com/metosin/ring-
 
 * Fork the repository on Github
 * Create a topic branch from where you want to base your work (usually the master branch)
-* Check the formatting rules from existing code (no trailing whitepace, mostly default indentation)
+* Check the formatting rules from existing code (no trailing whitespace, mostly default indentation)
 * Ensure any new code is well-tested, and if possible, any issue fixed is covered by one or more new tests
 * Verify that all tests pass using ```lein all```
 * Push your code to your fork of the repository

--- a/src/ring/util/http_predicates.clj
+++ b/src/ring/util/http_predicates.clj
@@ -4,429 +4,429 @@
   "Check whether the response type is Informational (status code is between
   100 and 199)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 100 (:status response) 199))
 
 (defn success?
   "Check whether the response type is Success (status code is between
   200 and 299)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 200 (:status response) 299))
 
 (defn redirection?
   "Check whether the response type is Redirection (status code is between
   300 and 399)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 300 (:status response) 399))
 
 (defn client-error?
   "Check whether the response type is ClientError (status code is between
   400 and 499)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 400 (:status response) 499))
 
 (defn server-error?
   "Check whether the response type is ServerError (status code is between
   500 and 599)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 500 (:status response) 599))
 
 (defn continue?
   "Checks whether the response has status code 100"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 100))
 
 (defn switching-protocols?
   "Checks whether the response has status code 101"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 101))
 
 (defn processing?
   "Checks whether the response has status code 102"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 102))
 
 (defn ok?
   "Checks whether the response has status code 200"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 200))
 
 (defn created?
   "Checks whether the response has status code 201"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 201))
 
 (defn accepted?
   "Checks whether the response has status code 202"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 202))
 
 (defn non-authoritative-information?
   "Checks whether the response has status code 203"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 203))
 
 (defn no-content?
   "Checks whether the response has status code 204"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 204))
 
 (defn reset-content?
   "Checks whether the response has status code 205"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 205))
 
 (defn partial-content?
   "Checks whether the response has status code 206"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 206))
 
 (defn multi-status?
   "Checks whether the response has status code 207"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 207))
 
 (defn already-reported?
   "Checks whether the response has status code 208"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 208))
 
 (defn im-used?
   "Checks whether the response has status code 226"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 226))
 
 (defn multiple-choices?
   "Checks whether the response has status code 300"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 300))
 
 (defn moved-permanently?
   "Checks whether the response has status code 301"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 301))
 
 (defn found?
   "Checks whether the response has status code 302"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 302))
 
 (defn see-other?
   "Checks whether the response has status code 303"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 303))
 
 (defn not-modified?
   "Checks whether the response has status code 304"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 304))
 
 (defn use-proxy?
   "Checks whether the response has status code 305"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 305))
 
 (defn temporary-redirect?
   "Checks whether the response has status code 307"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 307))
 
 (defn permanent-redirect?
   "Checks whether the response has status code 308"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 308))
 
 (defn bad-request?
   "Checks whether the response has status code 400"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 400))
 
 (defn unauthorized?
   "Checks whether the response has status code 401"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 401))
 
 (defn payment-required?
   "Checks whether the response has status code 402"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 402))
 
 (defn forbidden?
   "Checks whether the response has status code 403"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 403))
 
 (defn not-found?
   "Checks whether the response has status code 404"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 404))
 
 (defn method-not-allowed?
   "Checks whether the response has status code 405"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 405))
 
 (defn not-acceptable?
   "Checks whether the response has status code 406"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 406))
 
 (defn proxy-authentication-required?
   "Checks whether the response has status code 407"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 407))
 
 (defn request-timeout?
   "Checks whether the response has status code 408"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 408))
 
 (defn conflict?
   "Checks whether the response has status code 409"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 409))
 
 (defn gone?
   "Checks whether the response has status code 410"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 410))
 
 (defn length-required?
   "Checks whether the response has status code 411"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 411))
 
 (defn precondition-failed?
   "Checks whether the response has status code 412"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 412))
 
 (defn request-entity-too-large?
   "Checks whether the response has status code 413"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 413))
 
 (defn request-uri-too-long?
   "Checks whether the response has status code 414"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 414))
 
 (defn unsupported-media-type?
   "Checks whether the response has status code 415"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 415))
 
 (defn requested-range-not-satisfiable?
   "Checks whether the response has status code 416"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 416))
 
 (defn expectation-failed?
   "Checks whether the response has status code 417"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 417))
 
 (defn im-a-teapot?
   "Checks whether the response has status code 418"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 418))
 
 (defn enhance-your-calm?
   "Checks whether the response has status code 420"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 420))
 
 (defn unprocessable-entity?
   "Checks whether the response has status code 422"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 422))
 
 (defn locked?
   "Checks whether the response has status code 423"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 423))
 
 (defn failed-dependency?
   "Checks whether the response has status code 424"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 424))
 
 (defn unordered-collection?
   "Checks whether the response has status code 425"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 425))
 
 (defn upgrade-required?
   "Checks whether the response has status code 426"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 426))
 
 (defn precondition-required?
   "Checks whether the response has status code 428"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 428))
 
 (defn too-many-requests?
   "Checks whether the response has status code 429"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 429))
 
 (defn request-header-fields-too-large?
   "Checks whether the response has status code 431"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 431))
 
 (defn retry-with?
   "Checks whether the response has status code 449"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 449))
 
 (defn blocked-by-windows-parental-controls?
   "Checks whether the response has status code 450"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 450))
 
 (defn unavailable-for-legal-reasons?
   "Checks whether the response has status code 451"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 451))
 
 (defn internal-server-error?
   "Checks whether the response has status code 500"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 500))
 
 (defn not-implemented?
   "Checks whether the response has status code 501"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 501))
 
 (defn bad-gateway?
   "Checks whether the response has status code 502"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 502))
 
 (defn service-unavailable?
   "Checks whether the response has status code 503"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 503))
 
 (defn gateway-timeout?
   "Checks whether the response has status code 504"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 504))
 
 (defn http-version-not-supported?
   "Checks whether the response has status code 505"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 505))
 
 (defn variant-also-negotiates?
   "Checks whether the response has status code 506"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 506))
 
 (defn insufficient-storage?
   "Checks whether the response has status code 507"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 507))
 
 (defn loop-detected?
   "Checks whether the response has status code 508"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 508))
 
 (defn bandwidth-limit-exceeded?
   "Checks whether the response has status code 509"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 509))
 
 (defn not-extended?
   "Checks whether the response has status code 510"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 510))
 
 (defn network-authentication-required?
   "Checks whether the response has status code 511"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 511))
 
 (defn network-read-timeout?
   "Checks whether the response has status code 598"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 598))
 
 (defn network-connect-timeout?
   "Checks whether the response has status code 599"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 599))

--- a/src/ring/util/http_predicates.cljs
+++ b/src/ring/util/http_predicates.cljs
@@ -4,429 +4,429 @@
   "Check whether the response type is Informational (status code is between
   100 and 199)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 100 (:status response) 199))
 
 (defn success?
   "Check whether the response type is Success (status code is between
   200 and 299)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 200 (:status response) 299))
 
 (defn redirection?
   "Check whether the response type is Redirection (status code is between
   300 and 399)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 300 (:status response) 399))
 
 (defn client-error?
   "Check whether the response type is ClientError (status code is between
   400 and 499)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 400 (:status response) 499))
 
 (defn server-error?
   "Check whether the response type is ServerError (status code is between
   500 and 599)."
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (<= 500 (:status response) 599))
 
 (defn continue?
   "Checks whether the response has status code 100"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 100))
 
 (defn switching-protocols?
   "Checks whether the response has status code 101"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 101))
 
 (defn processing?
   "Checks whether the response has status code 102"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 102))
 
 (defn ok?
   "Checks whether the response has status code 200"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 200))
 
 (defn created?
   "Checks whether the response has status code 201"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 201))
 
 (defn accepted?
   "Checks whether the response has status code 202"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 202))
 
 (defn non-authoritative-information?
   "Checks whether the response has status code 203"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 203))
 
 (defn no-content?
   "Checks whether the response has status code 204"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 204))
 
 (defn reset-content?
   "Checks whether the response has status code 205"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 205))
 
 (defn partial-content?
   "Checks whether the response has status code 206"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 206))
 
 (defn multi-status?
   "Checks whether the response has status code 207"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 207))
 
 (defn already-reported?
   "Checks whether the response has status code 208"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 208))
 
 (defn im-used?
   "Checks whether the response has status code 226"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 226))
 
 (defn multiple-choices?
   "Checks whether the response has status code 300"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 300))
 
 (defn moved-permanently?
   "Checks whether the response has status code 301"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 301))
 
 (defn found?
   "Checks whether the response has status code 302"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 302))
 
 (defn see-other?
   "Checks whether the response has status code 303"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 303))
 
 (defn not-modified?
   "Checks whether the response has status code 304"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 304))
 
 (defn use-proxy?
   "Checks whether the response has status code 305"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 305))
 
 (defn temporary-redirect?
   "Checks whether the response has status code 307"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 307))
 
 (defn permanent-redirect?
   "Checks whether the response has status code 308"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 308))
 
 (defn bad-request?
   "Checks whether the response has status code 400"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 400))
 
 (defn unauthorized?
   "Checks whether the response has status code 401"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 401))
 
 (defn payment-required?
   "Checks whether the response has status code 402"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 402))
 
 (defn forbidden?
   "Checks whether the response has status code 403"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 403))
 
 (defn not-found?
   "Checks whether the response has status code 404"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 404))
 
 (defn method-not-allowed?
   "Checks whether the response has status code 405"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 405))
 
 (defn not-acceptable?
   "Checks whether the response has status code 406"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 406))
 
 (defn proxy-authentication-required?
   "Checks whether the response has status code 407"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 407))
 
 (defn request-timeout?
   "Checks whether the response has status code 408"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 408))
 
 (defn conflict?
   "Checks whether the response has status code 409"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 409))
 
 (defn gone?
   "Checks whether the response has status code 410"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 410))
 
 (defn length-required?
   "Checks whether the response has status code 411"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 411))
 
 (defn precondition-failed?
   "Checks whether the response has status code 412"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 412))
 
 (defn request-entity-too-large?
   "Checks whether the response has status code 413"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 413))
 
 (defn request-uri-too-long?
   "Checks whether the response has status code 414"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 414))
 
 (defn unsupported-media-type?
   "Checks whether the response has status code 415"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 415))
 
 (defn requested-range-not-satisfiable?
   "Checks whether the response has status code 416"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 416))
 
 (defn expectation-failed?
   "Checks whether the response has status code 417"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 417))
 
 (defn im-a-teapot?
   "Checks whether the response has status code 418"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 418))
 
 (defn enhance-your-calm?
   "Checks whether the response has status code 420"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 420))
 
 (defn unprocessable-entity?
   "Checks whether the response has status code 422"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 422))
 
 (defn locked?
   "Checks whether the response has status code 423"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 423))
 
 (defn failed-dependency?
   "Checks whether the response has status code 424"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 424))
 
 (defn unordered-collection?
   "Checks whether the response has status code 425"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 425))
 
 (defn upgrade-required?
   "Checks whether the response has status code 426"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 426))
 
 (defn precondition-required?
   "Checks whether the response has status code 428"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 428))
 
 (defn too-many-requests?
   "Checks whether the response has status code 429"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 429))
 
 (defn request-header-fields-too-large?
   "Checks whether the response has status code 431"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 431))
 
 (defn retry-with?
   "Checks whether the response has status code 449"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 449))
 
 (defn blocked-by-windows-parental-controls?
   "Checks whether the response has status code 450"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 450))
 
 (defn unavailable-for-legal-reasons?
   "Checks whether the response has status code 451"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 451))
 
 (defn internal-server-error?
   "Checks whether the response has status code 500"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 500))
 
 (defn not-implemented?
   "Checks whether the response has status code 501"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 501))
 
 (defn bad-gateway?
   "Checks whether the response has status code 502"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 502))
 
 (defn service-unavailable?
   "Checks whether the response has status code 503"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 503))
 
 (defn gateway-timeout?
   "Checks whether the response has status code 504"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 504))
 
 (defn http-version-not-supported?
   "Checks whether the response has status code 505"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 505))
 
 (defn variant-also-negotiates?
   "Checks whether the response has status code 506"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 506))
 
 (defn insufficient-storage?
   "Checks whether the response has status code 507"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 507))
 
 (defn loop-detected?
   "Checks whether the response has status code 508"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 508))
 
 (defn bandwidth-limit-exceeded?
   "Checks whether the response has status code 509"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 509))
 
 (defn not-extended?
   "Checks whether the response has status code 510"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 510))
 
 (defn network-authentication-required?
   "Checks whether the response has status code 511"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 511))
 
 (defn network-read-timeout?
   "Checks whether the response has status code 598"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 598))
 
 (defn network-connect-timeout?
   "Checks whether the response has status code 599"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (= (:status response) 599))

--- a/src/ring/util/http_response.clj
+++ b/src/ring/util/http_response.clj
@@ -7,7 +7,7 @@
   {:type :ring.util.http-response/response
    :response response}"
   [response]
-  {:pre (map? response)}
+  {:pre [(map? response)]}
   (throw (ex-info (str "HTTP "(:status response)) {:type ::response :response response})))
 
 (defn continue
@@ -1144,7 +1144,7 @@
 
 (defn network-read-timeout!
   "598 Network read timeout (ServerError)
-  
+
   Throws an exception with ex-info:
   {:type :ring.util.http-response/response
    :response response}"
@@ -1166,7 +1166,7 @@
 
 (defn network-connect-timeout!
   "599 Network connect timeout (ServerError)
-  
+
   Throws an exception with ex-info:
   {:type :ring.util.http-response/response
    :response response}"

--- a/test/ring/util/http_predicates_test.clj
+++ b/test/ring/util/http_predicates_test.clj
@@ -436,6 +436,7 @@
     (is (thrown? AssertionError (network-read-timeout? nil)))
     (is (thrown? AssertionError (network-read-timeout? 123)))
 
+    (is (thrown? AssertionError (network-connect-timeout? "not-map")))
     (is (thrown? AssertionError (network-connect-timeout? :not-map)))
     (is (thrown? AssertionError (network-connect-timeout? nil)))
-    (is (thrown? AssertionError (network-connect-timeout? 123))) (is (thrown? AssertionError (network-connect-timeout? "not-map")))))
+    (is (thrown? AssertionError (network-connect-timeout? 123)))))

--- a/test/ring/util/http_predicates_test.clj
+++ b/test/ring/util/http_predicates_test.clj
@@ -83,4 +83,359 @@
     (is (network-authentication-required? {:status 511}))
     (is (network-read-timeout? {:status 598}))
     (is (network-connect-timeout? {:status 599}))
-    (is (server-error? {:status 504}))))
+    (is (server-error? {:status 504})))
+
+  (testing "Must throw assertion error when `response` parameter does not pass `map?` pre-condition"
+    (is (thrown? AssertionError (informational? "not-map")))
+    (is (thrown? AssertionError (informational? :not-map)))
+    (is (thrown? AssertionError (informational? nil)))
+    (is (thrown? AssertionError (informational? 123)))
+
+    (is (thrown? AssertionError (success? "not-map")))
+    (is (thrown? AssertionError (success? :not-map)))
+    (is (thrown? AssertionError (success? nil)))
+    (is (thrown? AssertionError (success? 123)))
+
+    (is (thrown? AssertionError (redirection? "not-map")))
+    (is (thrown? AssertionError (redirection? :not-map)))
+    (is (thrown? AssertionError (redirection? nil)))
+    (is (thrown? AssertionError (redirection? 123)))
+
+    (is (thrown? AssertionError (client-error? "not-map")))
+    (is (thrown? AssertionError (client-error? :not-map)))
+    (is (thrown? AssertionError (client-error? nil)))
+    (is (thrown? AssertionError (client-error? 123)))
+
+    (is (thrown? AssertionError (server-error? "not-map")))
+    (is (thrown? AssertionError (server-error? :not-map)))
+    (is (thrown? AssertionError (server-error? nil)))
+    (is (thrown? AssertionError (server-error? 123)))
+
+    (is (thrown? AssertionError (continue? "not-map")))
+    (is (thrown? AssertionError (continue? :not-map)))
+    (is (thrown? AssertionError (continue? nil)))
+    (is (thrown? AssertionError (continue? 123)))
+
+    (is (thrown? AssertionError (switching-protocols? "not-map")))
+    (is (thrown? AssertionError (switching-protocols? :not-map)))
+    (is (thrown? AssertionError (switching-protocols? nil)))
+    (is (thrown? AssertionError (switching-protocols? 123)))
+
+    (is (thrown? AssertionError (processing? "not-map")))
+    (is (thrown? AssertionError (processing? :not-map)))
+    (is (thrown? AssertionError (processing? nil)))
+    (is (thrown? AssertionError (processing? 123)))
+
+    (is (thrown? AssertionError (ok? "not-map")))
+    (is (thrown? AssertionError (ok? :not-map)))
+    (is (thrown? AssertionError (ok? nil)))
+    (is (thrown? AssertionError (ok? 123)))
+
+    (is (thrown? AssertionError (created? "not-map")))
+    (is (thrown? AssertionError (created? :not-map)))
+    (is (thrown? AssertionError (created? nil)))
+    (is (thrown? AssertionError (created? 123)))
+
+    (is (thrown? AssertionError (accepted? "not-map")))
+    (is (thrown? AssertionError (accepted? :not-map)))
+    (is (thrown? AssertionError (accepted? nil)))
+    (is (thrown? AssertionError (accepted? 123)))
+
+    (is (thrown? AssertionError (non-authoritative-information? "not-map")))
+    (is (thrown? AssertionError (non-authoritative-information? :not-map)))
+    (is (thrown? AssertionError (non-authoritative-information? nil)))
+    (is (thrown? AssertionError (non-authoritative-information? 123)))
+
+    (is (thrown? AssertionError (no-content? "not-map")))
+    (is (thrown? AssertionError (no-content? :not-map)))
+    (is (thrown? AssertionError (no-content? nil)))
+    (is (thrown? AssertionError (no-content? 123)))
+
+    (is (thrown? AssertionError (reset-content? "not-map")))
+    (is (thrown? AssertionError (reset-content? :not-map)))
+    (is (thrown? AssertionError (reset-content? nil)))
+    (is (thrown? AssertionError (reset-content? 123)))
+
+    (is (thrown? AssertionError (partial-content? "not-map")))
+    (is (thrown? AssertionError (partial-content? :not-map)))
+    (is (thrown? AssertionError (partial-content? nil)))
+    (is (thrown? AssertionError (partial-content? 123)))
+
+    (is (thrown? AssertionError (multi-status? "not-map")))
+    (is (thrown? AssertionError (multi-status? :not-map)))
+    (is (thrown? AssertionError (multi-status? nil)))
+    (is (thrown? AssertionError (multi-status? 123)))
+
+    (is (thrown? AssertionError (already-reported? "not-map")))
+    (is (thrown? AssertionError (already-reported? :not-map)))
+    (is (thrown? AssertionError (already-reported? nil)))
+    (is (thrown? AssertionError (already-reported? 123)))
+
+    (is (thrown? AssertionError (im-used? "not-map")))
+    (is (thrown? AssertionError (im-used? :not-map)))
+    (is (thrown? AssertionError (im-used? nil)))
+    (is (thrown? AssertionError (im-used? 123)))
+
+    (is (thrown? AssertionError (multiple-choices? "not-map")))
+    (is (thrown? AssertionError (multiple-choices? :not-map)))
+    (is (thrown? AssertionError (multiple-choices? nil)))
+    (is (thrown? AssertionError (multiple-choices? 123)))
+
+    (is (thrown? AssertionError (moved-permanently? "not-map")))
+    (is (thrown? AssertionError (moved-permanently? :not-map)))
+    (is (thrown? AssertionError (moved-permanently? nil)))
+    (is (thrown? AssertionError (moved-permanently? 123)))
+
+    (is (thrown? AssertionError (found? "not-map")))
+    (is (thrown? AssertionError (found? :not-map)))
+    (is (thrown? AssertionError (found? nil)))
+    (is (thrown? AssertionError (found? 123)))
+
+    (is (thrown? AssertionError (see-other? "not-map")))
+    (is (thrown? AssertionError (see-other? :not-map)))
+    (is (thrown? AssertionError (see-other? nil)))
+    (is (thrown? AssertionError (see-other? 123)))
+
+    (is (thrown? AssertionError (not-modified? "not-map")))
+    (is (thrown? AssertionError (not-modified? :not-map)))
+    (is (thrown? AssertionError (not-modified? nil)))
+    (is (thrown? AssertionError (not-modified? 123)))
+
+    (is (thrown? AssertionError (use-proxy? "not-map")))
+    (is (thrown? AssertionError (use-proxy? :not-map)))
+    (is (thrown? AssertionError (use-proxy? nil)))
+    (is (thrown? AssertionError (use-proxy? 123)))
+
+    (is (thrown? AssertionError (temporary-redirect? "not-map")))
+    (is (thrown? AssertionError (temporary-redirect? :not-map)))
+    (is (thrown? AssertionError (temporary-redirect? nil)))
+    (is (thrown? AssertionError (temporary-redirect? 123)))
+
+    (is (thrown? AssertionError (permanent-redirect? "not-map")))
+    (is (thrown? AssertionError (permanent-redirect? :not-map)))
+    (is (thrown? AssertionError (permanent-redirect? nil)))
+    (is (thrown? AssertionError (permanent-redirect? 123)))
+
+    (is (thrown? AssertionError (bad-request? "not-map")))
+    (is (thrown? AssertionError (bad-request? :not-map)))
+    (is (thrown? AssertionError (bad-request? nil)))
+    (is (thrown? AssertionError (bad-request? 123)))
+
+    (is (thrown? AssertionError (unauthorized? "not-map")))
+    (is (thrown? AssertionError (unauthorized? :not-map)))
+    (is (thrown? AssertionError (unauthorized? nil)))
+    (is (thrown? AssertionError (unauthorized? 123)))
+
+    (is (thrown? AssertionError (payment-required? "not-map")))
+    (is (thrown? AssertionError (payment-required? :not-map)))
+    (is (thrown? AssertionError (payment-required? nil)))
+    (is (thrown? AssertionError (payment-required? 123)))
+
+    (is (thrown? AssertionError (forbidden? "not-map")))
+    (is (thrown? AssertionError (forbidden? :not-map)))
+    (is (thrown? AssertionError (forbidden? nil)))
+    (is (thrown? AssertionError (forbidden? 123)))
+
+    (is (thrown? AssertionError (not-found? "not-map")))
+    (is (thrown? AssertionError (not-found? :not-map)))
+    (is (thrown? AssertionError (not-found? nil)))
+    (is (thrown? AssertionError (not-found? 123)))
+
+    (is (thrown? AssertionError (method-not-allowed? "not-map")))
+    (is (thrown? AssertionError (method-not-allowed? :not-map)))
+    (is (thrown? AssertionError (method-not-allowed? nil)))
+    (is (thrown? AssertionError (method-not-allowed? 123)))
+
+    (is (thrown? AssertionError (not-acceptable? "not-map")))
+    (is (thrown? AssertionError (not-acceptable? :not-map)))
+    (is (thrown? AssertionError (not-acceptable? nil)))
+    (is (thrown? AssertionError (not-acceptable? 123)))
+
+    (is (thrown? AssertionError (proxy-authentication-required? "not-map")))
+    (is (thrown? AssertionError (proxy-authentication-required? :not-map)))
+    (is (thrown? AssertionError (proxy-authentication-required? nil)))
+    (is (thrown? AssertionError (proxy-authentication-required? 123)))
+
+    (is (thrown? AssertionError (request-timeout? "not-map")))
+    (is (thrown? AssertionError (request-timeout? :not-map)))
+    (is (thrown? AssertionError (request-timeout? nil)))
+    (is (thrown? AssertionError (request-timeout? 123)))
+
+    (is (thrown? AssertionError (conflict? "not-map")))
+    (is (thrown? AssertionError (conflict? :not-map)))
+    (is (thrown? AssertionError (conflict? nil)))
+    (is (thrown? AssertionError (conflict? 123)))
+
+    (is (thrown? AssertionError (gone? "not-map")))
+    (is (thrown? AssertionError (gone? :not-map)))
+    (is (thrown? AssertionError (gone? nil)))
+    (is (thrown? AssertionError (gone? 123)))
+
+    (is (thrown? AssertionError (length-required? "not-map")))
+    (is (thrown? AssertionError (length-required? :not-map)))
+    (is (thrown? AssertionError (length-required? nil)))
+    (is (thrown? AssertionError (length-required? 123)))
+
+    (is (thrown? AssertionError (precondition-failed? "not-map")))
+    (is (thrown? AssertionError (precondition-failed? :not-map)))
+    (is (thrown? AssertionError (precondition-failed? nil)))
+    (is (thrown? AssertionError (precondition-failed? 123)))
+
+    (is (thrown? AssertionError (request-entity-too-large? "not-map")))
+    (is (thrown? AssertionError (request-entity-too-large? :not-map)))
+    (is (thrown? AssertionError (request-entity-too-large? nil)))
+    (is (thrown? AssertionError (request-entity-too-large? 123)))
+
+    (is (thrown? AssertionError (request-uri-too-long? "not-map")))
+    (is (thrown? AssertionError (request-uri-too-long? :not-map)))
+    (is (thrown? AssertionError (request-uri-too-long? nil)))
+    (is (thrown? AssertionError (request-uri-too-long? 123)))
+
+    (is (thrown? AssertionError (unsupported-media-type? "not-map")))
+    (is (thrown? AssertionError (unsupported-media-type? :not-map)))
+    (is (thrown? AssertionError (unsupported-media-type? nil)))
+    (is (thrown? AssertionError (unsupported-media-type? 123)))
+
+    (is (thrown? AssertionError (requested-range-not-satisfiable? "not-map")))
+    (is (thrown? AssertionError (requested-range-not-satisfiable? :not-map)))
+    (is (thrown? AssertionError (requested-range-not-satisfiable? nil)))
+    (is (thrown? AssertionError (requested-range-not-satisfiable? 123)))
+
+    (is (thrown? AssertionError (expectation-failed? "not-map")))
+    (is (thrown? AssertionError (expectation-failed? :not-map)))
+    (is (thrown? AssertionError (expectation-failed? nil)))
+    (is (thrown? AssertionError (expectation-failed? 123)))
+
+    (is (thrown? AssertionError (im-a-teapot? "not-map")))
+    (is (thrown? AssertionError (im-a-teapot? :not-map)))
+    (is (thrown? AssertionError (im-a-teapot? nil)))
+    (is (thrown? AssertionError (im-a-teapot? 123)))
+
+    (is (thrown? AssertionError (enhance-your-calm? "not-map")))
+    (is (thrown? AssertionError (enhance-your-calm? :not-map)))
+    (is (thrown? AssertionError (enhance-your-calm? nil)))
+    (is (thrown? AssertionError (enhance-your-calm? 123)))
+
+    (is (thrown? AssertionError (unprocessable-entity? "not-map")))
+    (is (thrown? AssertionError (unprocessable-entity? :not-map)))
+    (is (thrown? AssertionError (unprocessable-entity? nil)))
+    (is (thrown? AssertionError (unprocessable-entity? 123)))
+
+    (is (thrown? AssertionError (locked? "not-map")))
+    (is (thrown? AssertionError (locked? :not-map)))
+    (is (thrown? AssertionError (locked? nil)))
+    (is (thrown? AssertionError (locked? 123)))
+
+    (is (thrown? AssertionError (failed-dependency? "not-map")))
+    (is (thrown? AssertionError (failed-dependency? :not-map)))
+    (is (thrown? AssertionError (failed-dependency? nil)))
+    (is (thrown? AssertionError (failed-dependency? 123)))
+
+    (is (thrown? AssertionError (unordered-collection? "not-map")))
+    (is (thrown? AssertionError (unordered-collection? :not-map)))
+    (is (thrown? AssertionError (unordered-collection? nil)))
+    (is (thrown? AssertionError (unordered-collection? 123)))
+
+    (is (thrown? AssertionError (upgrade-required? "not-map")))
+    (is (thrown? AssertionError (upgrade-required? :not-map)))
+    (is (thrown? AssertionError (upgrade-required? nil)))
+    (is (thrown? AssertionError (upgrade-required? 123)))
+
+    (is (thrown? AssertionError (precondition-required? "not-map")))
+    (is (thrown? AssertionError (precondition-required? :not-map)))
+    (is (thrown? AssertionError (precondition-required? nil)))
+    (is (thrown? AssertionError (precondition-required? 123)))
+
+    (is (thrown? AssertionError (too-many-requests? "not-map")))
+    (is (thrown? AssertionError (too-many-requests? :not-map)))
+    (is (thrown? AssertionError (too-many-requests? nil)))
+    (is (thrown? AssertionError (too-many-requests? 123)))
+
+    (is (thrown? AssertionError (request-header-fields-too-large? "not-map")))
+    (is (thrown? AssertionError (request-header-fields-too-large? :not-map)))
+    (is (thrown? AssertionError (request-header-fields-too-large? nil)))
+    (is (thrown? AssertionError (request-header-fields-too-large? 123)))
+
+    (is (thrown? AssertionError (retry-with? "not-map")))
+    (is (thrown? AssertionError (retry-with? :not-map)))
+    (is (thrown? AssertionError (retry-with? nil)))
+    (is (thrown? AssertionError (retry-with? 123)))
+
+    (is (thrown? AssertionError (blocked-by-windows-parental-controls? "not-map")))
+    (is (thrown? AssertionError (blocked-by-windows-parental-controls? :not-map)))
+    (is (thrown? AssertionError (blocked-by-windows-parental-controls? nil)))
+    (is (thrown? AssertionError (blocked-by-windows-parental-controls? 123)))
+
+    (is (thrown? AssertionError (unavailable-for-legal-reasons? "not-map")))
+    (is (thrown? AssertionError (unavailable-for-legal-reasons? :not-map)))
+    (is (thrown? AssertionError (unavailable-for-legal-reasons? nil)))
+    (is (thrown? AssertionError (unavailable-for-legal-reasons? 123)))
+
+    (is (thrown? AssertionError (internal-server-error? "not-map")))
+    (is (thrown? AssertionError (internal-server-error? :not-map)))
+    (is (thrown? AssertionError (internal-server-error? nil)))
+    (is (thrown? AssertionError (internal-server-error? 123)))
+
+    (is (thrown? AssertionError (not-implemented? "not-map")))
+    (is (thrown? AssertionError (not-implemented? :not-map)))
+    (is (thrown? AssertionError (not-implemented? nil)))
+    (is (thrown? AssertionError (not-implemented? 123)))
+
+    (is (thrown? AssertionError (bad-gateway? "not-map")))
+    (is (thrown? AssertionError (bad-gateway? :not-map)))
+    (is (thrown? AssertionError (bad-gateway? nil)))
+    (is (thrown? AssertionError (bad-gateway? 123)))
+
+    (is (thrown? AssertionError (service-unavailable? "not-map")))
+    (is (thrown? AssertionError (service-unavailable? :not-map)))
+    (is (thrown? AssertionError (service-unavailable? nil)))
+    (is (thrown? AssertionError (service-unavailable? 123)))
+
+    (is (thrown? AssertionError (gateway-timeout? "not-map")))
+    (is (thrown? AssertionError (gateway-timeout? :not-map)))
+    (is (thrown? AssertionError (gateway-timeout? nil)))
+    (is (thrown? AssertionError (gateway-timeout? 123)))
+
+    (is (thrown? AssertionError (http-version-not-supported? "not-map")))
+    (is (thrown? AssertionError (http-version-not-supported? :not-map)))
+    (is (thrown? AssertionError (http-version-not-supported? nil)))
+    (is (thrown? AssertionError (http-version-not-supported? 123)))
+
+    (is (thrown? AssertionError (variant-also-negotiates? "not-map")))
+    (is (thrown? AssertionError (variant-also-negotiates? :not-map)))
+    (is (thrown? AssertionError (variant-also-negotiates? nil)))
+    (is (thrown? AssertionError (variant-also-negotiates? 123)))
+
+    (is (thrown? AssertionError (insufficient-storage? "not-map")))
+    (is (thrown? AssertionError (insufficient-storage? :not-map)))
+    (is (thrown? AssertionError (insufficient-storage? nil)))
+    (is (thrown? AssertionError (insufficient-storage? 123)))
+
+    (is (thrown? AssertionError (loop-detected? "not-map")))
+    (is (thrown? AssertionError (loop-detected? :not-map)))
+    (is (thrown? AssertionError (loop-detected? nil)))
+    (is (thrown? AssertionError (loop-detected? 123)))
+
+    (is (thrown? AssertionError (bandwidth-limit-exceeded? "not-map")))
+    (is (thrown? AssertionError (bandwidth-limit-exceeded? :not-map)))
+    (is (thrown? AssertionError (bandwidth-limit-exceeded? nil)))
+    (is (thrown? AssertionError (bandwidth-limit-exceeded? 123)))
+
+    (is (thrown? AssertionError (not-extended? "not-map")))
+    (is (thrown? AssertionError (not-extended? :not-map)))
+    (is (thrown? AssertionError (not-extended? nil)))
+    (is (thrown? AssertionError (not-extended? 123)))
+
+    (is (thrown? AssertionError (network-authentication-required? "not-map")))
+    (is (thrown? AssertionError (network-authentication-required? :not-map)))
+    (is (thrown? AssertionError (network-authentication-required? nil)))
+    (is (thrown? AssertionError (network-authentication-required? 123)))
+
+    (is (thrown? AssertionError (network-read-timeout? "not-map")))
+    (is (thrown? AssertionError (network-read-timeout? :not-map)))
+    (is (thrown? AssertionError (network-read-timeout? nil)))
+    (is (thrown? AssertionError (network-read-timeout? 123)))
+
+    (is (thrown? AssertionError (network-connect-timeout? :not-map)))
+    (is (thrown? AssertionError (network-connect-timeout? nil)))
+    (is (thrown? AssertionError (network-connect-timeout? 123))) (is (thrown? AssertionError (network-connect-timeout? "not-map")))))

--- a/test/ring/util/http_response_test.clj
+++ b/test/ring/util/http_response_test.clj
@@ -155,6 +155,13 @@
   (is (slingshots? {:status 400 :headers {} :body "body"} (throw! (bad-request "body"))))
   (is (slingshots? {:status 400 :headers {"a" "1"} :body "body"} (throw! (header (bad-request "body") "a" "1")))))
 
+(deftest throw!-parameter-validation-test
+  (testing "Must throw assertion error when `response` parameter does not pass `map?` pre-condition"
+    (is (thrown? AssertionError (throw! "not-map")))
+    (is (thrown? AssertionError (throw! :not-map)))
+    (is (thrown? AssertionError (throw! nil)))
+    (is (thrown? AssertionError (throw! 123)))))
+
 (deftest imported-vars-test
   (doseq [v [#'status
              #'header


### PR DESCRIPTION
The code being fixed in this commit does not use proper syntax to specify :pre conditions. As a result, when any of the predicate functions are provided with the `response` parameter that is not a map, instead of throwing an assertion error, execution reaches `(:status response)` whereupon it produces `NullPointerException`.

This might cause confusion as to the origin of the error because the developer might not know or remember the proper syntax of the :pre conditions, and upon seeing that some code is present in the `:pre` header of the predicate functions they are using, they discard the possibility that it might be the `response` parameter they are providing to these functions that causes an error, assuming that the predicate functions take care of validating the proper type of the `response` parameter.

[Judging from the way `:pre` condition gets added to the function definition](https://github.com/clojure/clojure/blob/ce55092f2b2f5481d25cff6205470c1335760ef6/src/clj/clojure/core.clj#L4588), current implementation uses the syntax which doesn't fail to operate only because the `assert` function returns `nil` upon receiving a reference to a function and upon receiving the instance of the data type by itself, but the code does fail to fulfill its purpose, it doesn't really "work" as is.

```clojure
;; part of code used to add pre to the body of the function:
(if pre
  (concat (map (fn* [c] `(assert ~c)) pre)
          body)
  body)

;; testing `map` function above with invalid and valid :pre conditions:

;; - invalid:
(map (fn* [c]
          (do
            (println "this is c" c)
            `(assert ~c))) '(map? "not-map"))

; this is c map?
; this is c not-map
((clojure.core/assert map?) ;; => nil
 (clojure.core/assert "not-map") ;; = nil
 )

;; - valid:
(map (fn* [c]
          (do
            (println "this is c" c)
            `(assert ~c))) '[(map? "not-map")])

; this is c (map? not-map)
((clojure.core/assert (map? "not-map")
  ;; \\> Execution error (AssertionError) ... Assert failed: (map? "not-map")
  ))
```